### PR TITLE
fix issue of non-ending mentions of GRE matching

### DIFF
--- a/etc/meGRE_bids_corrector.py
+++ b/etc/meGRE_bids_corrector.py
@@ -47,12 +47,12 @@ for js,ni in zip(json_files, nifti_files):
     #in the case of echo-1, the EchoNumber tag does not exist in the json file    
     if ("EchoNumber" not in json_data) and ("_echo_" in js):
         js_addEchoNum = re.sub("_echo_", "_echo-1_", js)
-        js_changeEnding = re.sub("GRE.*", "GRE.json", js_addEchoNum)
+        js_changeEnding = re.sub("_GRE[0-9]*", "GRE.json", js_addEchoNum)
         print('renaming: '+js+' to '+js_changeEnding)
         os.rename(js, js_changeEnding)
         
         ni_addEchoNum = re.sub("_echo_", "_echo-1_", ni)
-        ni_changeEnding = re.sub("GRE.*", "GRE.nii.gz", ni_addEchoNum)
+        ni_changeEnding = re.sub("_GRE[0-9]*", "GRE.nii.gz", ni_addEchoNum)
         print('renaming: '+ni+' to '+ni_changeEnding)
         os.rename(ni, ni_changeEnding)
     
@@ -61,12 +61,11 @@ for js,ni in zip(json_files, nifti_files):
         echonum = json_data["EchoNumber"]
         
         js_addEchoNum = re.sub("_echo_", "_echo-" + str(echonum) + "_", js)
-        js_changeEnding = re.sub("GRE.*", "GRE.json", js_addEchoNum)
+        js_changeEnding = re.sub("_GRE[0-9]*", "GRE.json", js_addEchoNum)
         print('renaming: '+js+' to '+js_changeEnding)
         os.rename(js, js_changeEnding)
         
         ni_addEchoNum = re.sub("_echo_", "_echo-" + str(echonum) + "_", ni)
-        ni_changeEnding = re.sub("GRE.*", "GRE.nii.gz", ni_addEchoNum)
+        ni_changeEnding = re.sub("_GRE[0-9]*", "GRE.nii.gz", ni_addEchoNum)
         print('renaming: '+ni+' to '+ni_changeEnding)
         os.rename(ni, ni_changeEnding)
-

--- a/etc/meGRE_bids_corrector.py
+++ b/etc/meGRE_bids_corrector.py
@@ -47,12 +47,12 @@ for js,ni in zip(json_files, nifti_files):
     #in the case of echo-1, the EchoNumber tag does not exist in the json file    
     if ("EchoNumber" not in json_data) and ("_echo_" in js):
         js_addEchoNum = re.sub("_echo_", "_echo-1_", js)
-        js_changeEnding = re.sub("_GRE[0-9]*", "GRE.json", js_addEchoNum)
+        js_changeEnding = re.sub("_GRE[0-9].json", "GRE.json", js_addEchoNum)
         print('renaming: '+js+' to '+js_changeEnding)
         os.rename(js, js_changeEnding)
         
         ni_addEchoNum = re.sub("_echo_", "_echo-1_", ni)
-        ni_changeEnding = re.sub("_GRE[0-9]*", "GRE.nii.gz", ni_addEchoNum)
+        ni_changeEnding = re.sub("_GRE[0-9].nii.gz", "GRE.nii.gz", ni_addEchoNum)
         print('renaming: '+ni+' to '+ni_changeEnding)
         os.rename(ni, ni_changeEnding)
     
@@ -61,11 +61,11 @@ for js,ni in zip(json_files, nifti_files):
         echonum = json_data["EchoNumber"]
         
         js_addEchoNum = re.sub("_echo_", "_echo-" + str(echonum) + "_", js)
-        js_changeEnding = re.sub("_GRE[0-9]*", "GRE.json", js_addEchoNum)
+        js_changeEnding = re.sub("_GRE[0-9].json", "GRE.json", js_addEchoNum)
         print('renaming: '+js+' to '+js_changeEnding)
         os.rename(js, js_changeEnding)
         
         ni_addEchoNum = re.sub("_echo_", "_echo-" + str(echonum) + "_", ni)
-        ni_changeEnding = re.sub("_GRE[0-9]*", "GRE.nii.gz", ni_addEchoNum)
+        ni_changeEnding = re.sub("_GRE[0-9].nii.gz", "GRE.nii.gz", ni_addEchoNum)
         print('renaming: '+ni+' to '+ni_changeEnding)
         os.rename(ni, ni_changeEnding)


### PR DESCRIPTION
1) The underscore should avoid all BIDS descriptor mentions of GRE. (i.e. sub-GRE, acq-GRE, etc.) since underscore is a special character in BIDS naming scheme to be used only between tags

2) The number matching will ensure only redundant information is renamed. 
E.g. we want to rename GRE(1-4) to GRE (since it will be attached to echo-(1-4)), but if there are other meaningful descriptors that follow, they will not be lost.