### PR TITLE
Pin conda to 4.10.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM neurodebian:xenial
-MAINTAINER <alik@robarts.ca>
+LABEL maintainer="<alik@robarts.ca>"
 
 #heudiconv version:
 ENV HEUDICONVTAG v0.5.4
@@ -94,7 +94,7 @@ RUN export PATH="/opt/miniconda-latest/bin:$PATH" \
     && curl -fsSL --retry 5 -o "$conda_installer" https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh \
     && bash "$conda_installer" -b -p /opt/miniconda-latest \
     && rm -f "$conda_installer" \
-    && conda update -yq -nbase conda \
+    && conda install -yq -nbase conda=4.10.3 \
     && conda config --system --prepend channels conda-forge \
     && conda config --system --set auto_update_conda false \
     && conda config --system --set show_channel_urls true \


### PR DESCRIPTION
Conda >=4.11.0 has requirements that seem not to be supported to Ubuntu Xenial (itself pretty old). As a short-term fix, this PR pins the Conda version to 4.10.3, allowing the Docker image to build successfully.

In the longer term, it would be good to use a more recent version of Neurodebian to build this container, which I'll look into later.