### PR TITLE
accessory python script bugfix, Heudiconv v0.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,10 +5,10 @@ LABEL maintainer="<alik@robarts.ca>"
 ENV DCM2NIIXTAG v1.0.20210317
 
 #heudiconv version:
-ENV HEUDICONVTAG v0.5.4
+ENV HEUDICONVTAG v0.10.0
 
 #bids validator version:
-ENV BIDSTAG 1.2.5
+ENV BIDSTAG 1.9.3
 
 #pydeface version:
 ENV PYDEFACETAG v1.1.0

--- a/etc/correctFieldMapJson.py
+++ b/etc/correctFieldMapJson.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 '''
 correct field map json
 '''

--- a/etc/correctFieldMapJsonCase2.py
+++ b/etc/correctFieldMapJsonCase2.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 '''
 correct field map json
 '''

--- a/etc/fixImFreq_json.py
+++ b/etc/fixImFreq_json.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # import modules
 import os

--- a/etc/genPhaseFromComplexNii.py
+++ b/etc/genPhaseFromComplexNii.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import sys
 import numpy as np

--- a/etc/magfmap_bids_corrector.py
+++ b/etc/magfmap_bids_corrector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # import modules
 import os

--- a/etc/magphase_sa2rage_bids_corrector.py
+++ b/etc/magphase_sa2rage_bids_corrector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # import modules
 import os

--- a/etc/meEPI_bids_corrector.py
+++ b/etc/meEPI_bids_corrector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # import modules
 import os

--- a/etc/meGRE_bids_corrector.py
+++ b/etc/meGRE_bids_corrector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # import modules
 import os

--- a/etc/merge_vNav.py
+++ b/etc/merge_vNav.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import os
 import sys

--- a/etc/mp2rage_genUniDen.py
+++ b/etc/mp2rage_genUniDen.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import sys

--- a/etc/pdt2_bids_corrector.py
+++ b/etc/pdt2_bids_corrector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # import modules
 import os

--- a/etc/twomagphase_bids_corrector.py
+++ b/etc/twomagphase_bids_corrector.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 # import modules
 import os

--- a/tar2bids
+++ b/tar2bids
@@ -435,7 +435,7 @@ fi
 fi
 
 #merge any vNav files if they exist
-python $execpath/etc/merge_vNav.py $output_dir
+python3 $execpath/etc/merge_vNav.py $output_dir
 
 #remove scans.tsv files as they may be out of date after corrections
 rm -f $output_dir/*/*_scans.tsv $output_dir/*/*/*_scans.tsv


### PR DESCRIPTION
- upgrades heudiconv to v0.10.0 (latest release)
- fixes bug (from tar2bids v0.1.0 onwards) where python scripts in `etc/` cannot run since `/usr/bin/python` doesn't exist (ie is not symlinked to python3)
