### PR TITLE
Miscellaneous bug fixes and updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,10 @@ FROM debian:bullseye
 LABEL maintainer="<alik@robarts.ca>"
 
 # dcm2niix version
-ENV DCM2NIIXTAG v1.0.20220720
+ENV DCM2NIIXTAG v1.0.20230411
 
 #heudiconv version:
-ENV HEUDICONVTAG v0.11.3
+ENV HEUDICONVTAG v0.13.1
 
 #bids validator version:
 ENV BIDSTAG 1.9.7

--- a/heuristics/cfmm_base.py
+++ b/heuristics/cfmm_base.py
@@ -1,6 +1,6 @@
 import os
 
-def create_key(template, outtype=('nii.gz'), annotation_classes=None):
+def create_key(template, outtype=('nii.gz',), annotation_classes=None):
     if template is None or not template:
         raise ValueError('Template must be a valid format string')
     return (template, outtype, annotation_classes)

--- a/tar2bids
+++ b/tar2bids
@@ -499,7 +499,7 @@ else
 fi
 
 echo "  Removing _ROI#.nii.gz files (unused scale bars from qMRI)..."
-rm -vf $output_dir/sub*/*/*ROI[0-9].nii.gz $output_dir/sub*/ses*/*ROI[0-9].nii.gz 2> /dev/null
+rm -vf $output_dir/sub*/*/*ROI[0-9].nii.gz $output_dir/sub*/ses*/*/*ROI[0-9].nii.gz 2> /dev/null
 
 echo "  Running bids-validator..."
 bids-validator $output_dir | tee  $validator_out


### PR DESCRIPTION
1. Fix the formatting of the default `outtype` in `cfmm_base.create_key`. This needs to be a tuple, but heudiconv used to silently wrap strings in a tuple. They removed that in version 0.13.0, causing `cfmm_base` to break.
2. Fix a typo in the _ROI file cleanup line to add the datatype directory in datasets with sessions.
3. Update heudiconv and dcm2niix