### PR TITLE
Remove .bval and .bvec files from anat (mp2rage)

### DIFF
--- a/tar2bids
+++ b/tar2bids
@@ -465,6 +465,9 @@ rm -f $output_dir/*/*_scans.tsv $output_dir/*/*/*_scans.tsv
 rm -f $output_dir/*/fmap/*.bval $output_dir/*/*/fmap/*.bval
 rm -f $output_dir/*/fmap/*.bvec $output_dir/*/*/fmap/*.bvec
 
+# remove .bval and .bvec files from anat (dcm2niix picking up header suggesting MP2RAGE is diffusion)
+rm -f $output_dir/*/anat/*.bval $output_dir/*/*/anat/*.bval
+rm -f $output_dir/*/anat/*.bvec $output_dir/*/*/anat/*.bvec
 
 if [ "$do_deface" = "1" ]
 then


### PR DESCRIPTION
Some recent MP2RAGE acquisitions now contain (0019, 100c) [B_value] in the DICOM header, causing `dcm2niix` to interpret these images as diffusion and generating a .bval and .bvec file. As it no longer follows the BIDS spec since these are not anatomical-associated files, the bids validation is failing.