### PR TITLE
Update cfmm_base.py

### DIFF
--- a/heuristics/cfmm_base.py
+++ b/heuristics/cfmm_base.py
@@ -593,8 +593,8 @@ def infotodict(seqinfo):
                 if ('DIS3D' in (s.image_type[3].strip())):
                     info[DIS3D_spc_T2w].append({'item': s.series_id})
     
-        #spc T2w  
-        if ('spc_flair' in s.series_description or 'dark-fluid' in s.series_description): 
+        #spc FLAIR  
+        if ('spc_flair' in s.series_description or 'flair_spc' in s.series_description or 'dark-fluid' in s.series_description): 
             if ('ND' in (s.image_type[3].strip())):
                 info[spc_FLAIR].append({'item': s.series_id})
             if ('DIS2D' in (s.image_type[3].strip())):


### PR DESCRIPTION
series description for FLAIR space SNSX is now named `flair_spcir_sag_p6`, need to capture this series here