### PR TITLE
update cfmm_bruker heuristic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ LABEL maintainer="<alik@robarts.ca>"
 ENV DCM2NIIXTAG v1.0.20230411
 
 #heudiconv version:
-ENV HEUDICONVTAG v0.13.1
+ENV HEUDICONVTAG unstacked_dcm
 
 #bids validator version:
 ENV BIDSTAG 1.9.7
@@ -37,9 +37,22 @@ RUN apt-get update -qq \
     && apt-get install -y -q --no-install-recommends \
         python3=3.9.2-3 \
         python3-pip=20.3.4-4+deb11u1 \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
-    && pip install --no-cache-dir heudiconv==${HEUDICONVTAG}
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+RUN apt-get update -qq \
+    && apt-get install -y -q --no-install-recommends \
+        git \
+        python3-setuptools \
+    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* \
+    && git clone https://github.com/AlanKuurstra/heudiconv.git /src/heudiconv \
+    && git -C /src/heudiconv checkout ${HEUDICONVTAG}
+WORKDIR /src/heudiconv
+RUN python3 -m pip install --no-cache-dir -r /src/heudiconv/requirements.txt \
+    && python3 -m pip install --no-cache-dir versioningit \
+    && python3 /src/heudiconv/setup.py install
+
+# install pybruker for cfmm_bruker heuristic
+RUN python3 -m pip install --no-cache-dir pybruker --index-url https://gitlab.com/api/v4/projects/29466867/packages/pypi/simple
 
 # install BIDS Validator
 RUN apt-get update -qq \

--- a/heuristics/cfmm_bruker.py
+++ b/heuristics/cfmm_bruker.py
@@ -11,6 +11,7 @@ def create_key(template, outtype=('nii.gz',), annotation_classes=None):
         raise ValueError('Template must be a valid format string')
     return (template, outtype, annotation_classes)
 
+
 def infotodict(seqinfo):
     """Heuristic evaluator for determining which runs belong where
 
@@ -33,11 +34,9 @@ def infotodict(seqinfo):
     FLASH_MT_OFF = create_key('{bids_subject_session_dir}/anat/{bids_subject_session_prefix}_acq-MToff_run-{item:02d}_FLASH')
     dwi = create_key('{bids_subject_session_dir}/dwi/{bids_subject_session_prefix}_run-{item:02d}_dwi')
 
-    MP2RAGE_T1map = create_key('{bids_subject_session_dir}/anat/{bids_subject_session_prefix}_acq-MP2RAGE_run-{item:02d}_T1map')
     MP2RAGE_invs = create_key('{bids_subject_session_dir}/anat/{bids_subject_session_prefix}_acq-Inversions_run-{item:02d}_MP2RAGE')
     MP2RAGE_UNI = create_key('{bids_subject_session_dir}/anat/{bids_subject_session_prefix}_acq-UNI_run-{item:02d}_T1w')
 
-    MP2RAGE_T1map_l = create_key('{bids_subject_session_dir}/anat/{bids_subject_session_prefix}_acq-LoResMP2RAGE_run-{item:02d}_T1map')
     MP2RAGE_invs_l = create_key('{bids_subject_session_dir}/anat/{bids_subject_session_prefix}_acq-LoResInversions_run-{item:02d}_MP2RAGE')
     MP2RAGE_UNI_l = create_key('{bids_subject_session_dir}/anat/{bids_subject_session_prefix}_acq-LoResUNI_run-{item:02d}_T1w')
 
@@ -51,7 +50,7 @@ def infotodict(seqinfo):
     # where does bids_subject_session_prefix come from? or item? heudiconv special variables? can we get the task type (visual/audio) somehow?
     BLOCK_EPI =  create_key('{bids_subject_session_dir}/func/{bids_subject_session_prefix}_task-unknown_acq-BlockEPI_run-{item:02d}_bold')
 
-    info = { FLASH_T1:[],FLASH_MT_ON:[],FLASH_MT_OFF:[],dwi:[],MP2RAGE_T1map:[],MP2RAGE_invs:[],MP2RAGE_UNI:[],MP2RAGE_T1map_l:[],MP2RAGE_invs_l:[],MP2RAGE_UNI_l:[],MEGRE_mag:[],MEGRE_complex:[],T2_TurboRARE:[],BLOCK_EPI:[]}
+    info = { FLASH_T1:[],FLASH_MT_ON:[],FLASH_MT_OFF:[],dwi:[],MP2RAGE_invs:[],MP2RAGE_UNI:[],MP2RAGE_invs_l:[],MP2RAGE_UNI_l:[],MEGRE_mag:[],MEGRE_complex:[],T2_TurboRARE:[],BLOCK_EPI:[]}
 
     for idx, s in enumerate(seqinfo):
 
@@ -65,23 +64,19 @@ def infotodict(seqinfo):
             else:
                 info[FLASH_MT_ON].append({'item': s.series_id})
                 
-        elif ('DTI' in s.protocol_name):
+        elif ('dti' in s.protocol_name.lower()):
             info[dwi].append({'item': s.series_id})
         
-        elif ('MP2RAGE' in s.series_description.strip()):
+        elif ('cfmmMP2RAGE' in s.series_description.strip()):
           if (s.dim1 > 64):
             if  ('0001' in s.dcm_dir_name.strip()):
-                info[MP2RAGE_T1map].append({'item': s.series_id})
-            elif  ('0002' in s.dcm_dir_name.strip()):
                 info[MP2RAGE_invs].append({'item': s.series_id})
-            else:
+            elif  ('0002' in s.dcm_dir_name.strip()):
                 info[MP2RAGE_UNI].append({'item': s.series_id})
           else:
             if  ('0001' in s.dcm_dir_name.strip()):
-                info[MP2RAGE_T1map_l].append({'item': s.series_id})
-            elif  ('0002' in s.dcm_dir_name.strip()):
                 info[MP2RAGE_invs_l].append({'item': s.series_id})
-            else:
+            elif  ('0002' in s.dcm_dir_name.strip()):
                 info[MP2RAGE_UNI_l].append({'item': s.series_id})
 
         elif ('T2star' in s.series_description.strip()):


### PR DESCRIPTION
forked heudiconv to add capability of:
-  handling dicom datetimes with timezone info
- adding dicom metadata to .json sidecar when using a single n-dimensional dicom, when n>=4

changed tar2bids to:
- add blockEPI acquisition to bruker heuristic
- modify bruker heuristic to add bruker specific parameters to the .json sidecar
- use forked version of heudiconv (required for bruker data)